### PR TITLE
Remove many `unsafe` blocks

### DIFF
--- a/matching/src/parser.rs
+++ b/matching/src/parser.rs
@@ -122,15 +122,11 @@ impl<'a> Iterator for Select<'a> {
         let mut result: Option<Self::Item> = None;
 
         for node in &mut self.inner {
-            if node.value().is_element()
-                && self.expr.matches(
-                    unsafe { CssNodeRef::new_unchecked(node) },
-                    None,
-                    &mut self.caches,
-                )
-            {
-                result = Some(node);
-                break;
+            if let Some(css_node) = CssNodeRef::new(node) {
+                if self.expr.matches(css_node, None, &mut self.caches) {
+                    result = Some(node);
+                    break;
+                }
             }
         }
 

--- a/matching/src/selectable.rs
+++ b/matching/src/selectable.rs
@@ -32,10 +32,7 @@ impl selectors::Element for CssNodeRef<'_> {
     }
 
     fn parent_element(&self) -> Option<Self> {
-        self.0
-            .ancestors()
-            .find(|x| x.value().is_element())
-            .map(|x| unsafe { CssNodeRef::new_unchecked(x) })
+        self.0.ancestors().flat_map(CssNodeRef::new).next()
     }
 
     fn parent_node_is_shadow_root(&self) -> bool {
@@ -66,24 +63,15 @@ impl selectors::Element for CssNodeRef<'_> {
     }
 
     fn prev_sibling_element(&self) -> Option<Self> {
-        self.0
-            .prev_siblings()
-            .find(|sibling| sibling.value().is_element())
-            .map(|x| unsafe { Self::new_unchecked(x) })
+        self.0.prev_siblings().flat_map(Self::new).next()
     }
 
     fn next_sibling_element(&self) -> Option<Self> {
-        self.0
-            .next_siblings()
-            .find(|sibling| sibling.value().is_element())
-            .map(|x| unsafe { Self::new_unchecked(x) })
+        self.0.next_siblings().flat_map(Self::new).next()
     }
 
     fn first_element_child(&self) -> Option<Self> {
-        self.0
-            .children()
-            .find(|sibling| sibling.value().is_element())
-            .map(|x| unsafe { Self::new_unchecked(x) })
+        self.0.children().flat_map(Self::new).next()
     }
 
     fn is_html_element_in_html_document(&self) -> bool {

--- a/src/iter/iterator.rs
+++ b/src/iter/iterator.rs
@@ -18,7 +18,7 @@ impl PyIterator {
             .map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected TreeDom for dom, got {}",
-                    unsafe { crate::tools::get_type_name(dom.py(), dom.as_ptr()) }
+                    crate::tools::get_type_name(dom)
                 ))
             })?;
 
@@ -73,7 +73,7 @@ macro_rules! axis_iterators {
                     let node = crate::nodes::NodeGuard::from_pyobject(node).map_err(|_| {
                         pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                             "expected a node (such as Element, Text, Comment, ...) for node, got {}",
-                            unsafe { crate::tools::get_type_name(node.py(), node.as_ptr()) }
+                            crate::tools::get_type_name(node)
                         ))
                     })?;
 
@@ -126,7 +126,7 @@ impl PyChildren {
         let node = crate::nodes::NodeGuard::from_pyobject(node).map_err(|_| {
             pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                 "expected a node (such as Element, Text, Comment, ...) for node, got {}",
-                unsafe { crate::tools::get_type_name(node.py(), node.as_ptr()) }
+                crate::tools::get_type_name(node)
             ))
         })?;
 

--- a/src/iter/traverse.rs
+++ b/src/iter/traverse.rs
@@ -59,7 +59,7 @@ impl PyTraverse {
         let node = crate::nodes::NodeGuard::from_pyobject(node).map_err(|_| {
             pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                 "expected a node (such as Element, Text, Comment, ...) for node, got {}",
-                unsafe { crate::tools::get_type_name(node.py(), node.as_ptr()) }
+                crate::tools::get_type_name(node)
             ))
         })?;
 
@@ -90,7 +90,7 @@ impl PyDescendants {
         let node = crate::nodes::NodeGuard::from_pyobject(node).map_err(|_| {
             pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                 "expected a node (such as Element, Text, Comment, ...) for node, got {}",
-                unsafe { crate::tools::get_type_name(node.py(), node.as_ptr()) }
+                crate::tools::get_type_name(node)
             ))
         })?;
 

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -707,10 +707,10 @@ impl PyAttrsListItems {
         self_
     }
 
-    fn __next__(
-        self_: pyo3::PyRef<'_, Self>,
-        py: pyo3::Python<'_>,
-    ) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
+    fn __next__<'py>(
+        self_: pyo3::PyRef<'py, Self>,
+        py: pyo3::Python<'py>,
+    ) -> pyo3::PyResult<(super::qualname::PyQualName, pyo3::Py<pyo3::types::PyString>)> {
         let tree = self_.guard.tree.lock();
         let node = tree.get(self_.guard.id).unwrap().value().element().unwrap();
 
@@ -726,26 +726,11 @@ impl PyAttrsListItems {
 
         std::mem::drop(tree);
 
-        unsafe {
-            let key = pyo3::Py::new(
-                py,
-                super::qualname::PyQualName {
-                    name: (*attrkey).clone(),
-                },
-            )?;
-            let val = pyo3::types::PyString::new(py, &t_value);
-
-            let tuple = pyo3::ffi::PyTuple_New(2);
-
-            if tuple.is_null() {
-                return Err(pyo3::PyErr::fetch(py));
-            }
-
-            pyo3::ffi::PyTuple_SetItem(tuple, 0, key.into_ptr());
-            pyo3::ffi::PyTuple_SetItem(tuple, 1, val.into_ptr());
-
-            Ok(pyo3::Py::from_owned_ptr(py, tuple))
-        }
+        let key = super::qualname::PyQualName {
+            name: (*attrkey).clone(),
+        };
+        let val = pyo3::types::PyString::new(py, &t_value);
+        Ok((key, val.unbind()))
     }
 
     fn __len__(&self) -> usize {
@@ -958,7 +943,10 @@ impl PyAttrsList {
         }
     }
 
-    fn get_by_index(self_: pyo3::PyRef<'_, Self>, index: usize) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
+    fn get_by_index(
+        self_: pyo3::PyRef<'_, Self>,
+        index: usize,
+    ) -> pyo3::PyResult<(super::qualname::PyQualName, pyo3::Py<pyo3::types::PyString>)> {
         let mut tree = self_.0.tree.lock();
         let mut node = tree.get_mut(self_.0.id).unwrap();
         let elem = node.value().element_mut().unwrap();
@@ -971,31 +959,18 @@ impl PyAttrsList {
 
         let (attrkey, value) = elem.attrs.get(index).unwrap();
 
-        unsafe {
-            let key = pyo3::Py::new(
-                self_.py(),
-                super::qualname::PyQualName {
-                    name: attrkey.clone().into_qualname(),
-                },
-            )?;
-            let val = pyo3::types::PyString::new(self_.py(), value);
-
-            std::mem::drop(tree);
-
-            let tuple = pyo3::ffi::PyTuple_New(2);
-
-            if tuple.is_null() {
-                return Err(pyo3::PyErr::fetch(self_.py()));
-            }
-
-            pyo3::ffi::PyTuple_SetItem(tuple, 0, key.into_ptr());
-            pyo3::ffi::PyTuple_SetItem(tuple, 1, val.into_ptr());
-
-            Ok(pyo3::Py::from_owned_ptr(self_.py(), tuple))
-        }
+        let key = super::qualname::PyQualName {
+            name: attrkey.clone().into_qualname(),
+        };
+        let val = pyo3::types::PyString::new(self_.py(), value);
+        std::mem::drop(tree);
+        Ok((key, val.unbind()))
     }
 
-    fn remove(self_: pyo3::PyRef<'_, Self>, index: usize) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
+    fn remove(
+        self_: pyo3::PyRef<'_, Self>,
+        index: usize,
+    ) -> pyo3::PyResult<(super::qualname::PyQualName, pyo3::Py<pyo3::types::PyString>)> {
         let mut tree = self_.0.tree.lock();
         let mut node = tree.get_mut(self_.0.id).unwrap();
         let elem = node.value().element_mut().unwrap();
@@ -1010,29 +985,17 @@ impl PyAttrsList {
 
         std::mem::drop(tree);
 
-        unsafe {
-            let key = pyo3::Py::new(
-                self_.py(),
-                super::qualname::PyQualName {
-                    name: attrkey.into_qualname(),
-                },
-            )?;
-            let val = pyo3::types::PyString::new(self_.py(), &value);
-
-            let tuple = pyo3::ffi::PyTuple_New(2);
-
-            if tuple.is_null() {
-                return Err(pyo3::PyErr::fetch(self_.py()));
-            }
-
-            pyo3::ffi::PyTuple_SetItem(tuple, 0, key.into_ptr());
-            pyo3::ffi::PyTuple_SetItem(tuple, 1, val.into_ptr());
-
-            Ok(pyo3::Py::from_owned_ptr(self_.py(), tuple))
-        }
+        let key = super::qualname::PyQualName {
+            name: attrkey.into_qualname(),
+        };
+        let val = pyo3::types::PyString::new(self_.py(), &value);
+        Ok((key, val.unbind()))
     }
 
-    fn swap_remove(self_: pyo3::PyRef<'_, Self>, index: usize) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
+    fn swap_remove(
+        self_: pyo3::PyRef<'_, Self>,
+        index: usize,
+    ) -> pyo3::PyResult<(super::qualname::PyQualName, pyo3::Py<pyo3::types::PyString>)> {
         let mut tree = self_.0.tree.lock();
         let mut node = tree.get_mut(self_.0.id).unwrap();
         let elem = node.value().element_mut().unwrap();
@@ -1047,26 +1010,11 @@ impl PyAttrsList {
 
         std::mem::drop(tree);
 
-        unsafe {
-            let key = pyo3::Py::new(
-                self_.py(),
-                super::qualname::PyQualName {
-                    name: attrkey.into_qualname(),
-                },
-            )?;
-            let val = pyo3::types::PyString::new(self_.py(), &value);
-
-            let tuple = pyo3::ffi::PyTuple_New(2);
-
-            if tuple.is_null() {
-                return Err(pyo3::PyErr::fetch(self_.py()));
-            }
-
-            pyo3::ffi::PyTuple_SetItem(tuple, 0, key.into_ptr());
-            pyo3::ffi::PyTuple_SetItem(tuple, 1, val.into_ptr());
-
-            Ok(pyo3::Py::from_owned_ptr(self_.py(), tuple))
-        }
+        let key = super::qualname::PyQualName {
+            name: attrkey.into_qualname(),
+        };
+        let val = pyo3::types::PyString::new(self_.py(), &value);
+        Ok((key, val.unbind()))
     }
 
     fn dedup(&self) {

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -190,17 +190,15 @@ impl PartialEq for NodeGuard {
 impl Eq for NodeGuard {}
 
 macro_rules! create_richcmp_notimplemented {
-    ($token:expr, $selfobj:expr) => {
-        unsafe {
-            Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                format!(
-                    "'{}' not implemented for '{}'",
-                    $token,
-                    crate::tools::get_type_name($selfobj.py(), $selfobj.as_ptr()),
-                ),
-            ))
-        }
-    };
+    ($token:expr, $selfobj:expr) => {{
+        Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            format!(
+                "'{}' not implemented for '{}'",
+                $token,
+                crate::tools::get_type_name(&$selfobj),
+            ),
+        ))
+    }};
 }
 
 pub(crate) use create_richcmp_notimplemented;
@@ -254,7 +252,7 @@ impl PyDocument {
     }
 
     fn __richcmp__(
-        self_: pyo3::PyRef<'_, Self>,
+        self_: pyo3::Bound<Self>,
         other: pyo3::Py<pyo3::PyAny>,
         cmp: pyo3::basic::CompareOp,
     ) -> pyo3::PyResult<bool> {
@@ -271,7 +269,7 @@ impl PyDocument {
                     Err(_) => return Ok(false),
                 };
 
-                Ok(self_.0 == other.0)
+                Ok(self_.get().0 == other.0)
             }
             pyo3::basic::CompareOp::Ne => {
                 let other = match other.extract::<pyo3::PyRef<'_, Self>>(self_.py()) {
@@ -279,7 +277,7 @@ impl PyDocument {
                     Err(_) => return Ok(false),
                 };
 
-                Ok(self_.0 != other.0)
+                Ok(self_.get().0 != other.0)
             }
             pyo3::basic::CompareOp::Gt => {
                 create_richcmp_notimplemented!('>', self_)
@@ -319,7 +317,7 @@ impl PyDoctype {
             .map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected TreeDom for treedom, got {}",
-                    unsafe { crate::tools::get_type_name(treedom.py(), treedom.as_ptr()) }
+                    crate::tools::get_type_name(treedom)
                 ))
             })?;
 
@@ -410,7 +408,7 @@ impl PyDoctype {
     }
 
     fn __richcmp__(
-        self_: pyo3::PyRef<'_, Self>,
+        self_: pyo3::Bound<Self>,
         other: pyo3::Py<pyo3::PyAny>,
         cmp: pyo3::basic::CompareOp,
     ) -> pyo3::PyResult<bool> {
@@ -427,7 +425,7 @@ impl PyDoctype {
                     Err(_) => return Ok(false),
                 };
 
-                Ok(self_.0 == other.0)
+                Ok(self_.get().0 == other.0)
             }
             pyo3::basic::CompareOp::Ne => {
                 let other = match other.extract::<pyo3::PyRef<'_, Self>>(self_.py()) {
@@ -435,7 +433,7 @@ impl PyDoctype {
                     Err(_) => return Ok(false),
                 };
 
-                Ok(self_.0 != other.0)
+                Ok(self_.get().0 != other.0)
             }
             pyo3::basic::CompareOp::Gt => {
                 create_richcmp_notimplemented!('>', self_)
@@ -477,7 +475,7 @@ impl PyComment {
             .map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected TreeDom for treedom, got {}",
-                    unsafe { crate::tools::get_type_name(treedom.py(), treedom.as_ptr()) }
+                    crate::tools::get_type_name(treedom)
                 ))
             })?;
 
@@ -536,7 +534,7 @@ impl PyComment {
     }
 
     fn __richcmp__(
-        self_: pyo3::PyRef<'_, Self>,
+        self_: pyo3::Bound<Self>,
         other: pyo3::Py<pyo3::PyAny>,
         cmp: pyo3::basic::CompareOp,
     ) -> pyo3::PyResult<bool> {
@@ -553,7 +551,7 @@ impl PyComment {
                     Err(_) => return Ok(false),
                 };
 
-                Ok(self_.0 == other.0)
+                Ok(self_.get().0 == other.0)
             }
             pyo3::basic::CompareOp::Ne => {
                 let other = match other.extract::<pyo3::PyRef<'_, Self>>(self_.py()) {
@@ -561,7 +559,7 @@ impl PyComment {
                     Err(_) => return Ok(false),
                 };
 
-                Ok(self_.0 != other.0)
+                Ok(self_.get().0 != other.0)
             }
             pyo3::basic::CompareOp::Gt => {
                 create_richcmp_notimplemented!('>', self_)
@@ -600,7 +598,7 @@ impl PyText {
             .map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected TreeDom for treedom, got {}",
-                    unsafe { crate::tools::get_type_name(treedom.py(), treedom.as_ptr()) }
+                    crate::tools::get_type_name(treedom)
                 ))
             })?;
 
@@ -659,7 +657,7 @@ impl PyText {
     }
 
     fn __richcmp__(
-        self_: pyo3::PyRef<'_, Self>,
+        self_: pyo3::Bound<Self>,
         other: pyo3::Py<pyo3::PyAny>,
         cmp: pyo3::basic::CompareOp,
     ) -> pyo3::PyResult<bool> {
@@ -676,7 +674,7 @@ impl PyText {
                     Err(_) => return Ok(false),
                 };
 
-                Ok(self_.0 == other.0)
+                Ok(self_.get().0 == other.0)
             }
             pyo3::basic::CompareOp::Ne => {
                 let other = match other.extract::<pyo3::PyRef<'_, Self>>(self_.py()) {
@@ -684,7 +682,7 @@ impl PyText {
                     Err(_) => return Ok(false),
                 };
 
-                Ok(self_.0 != other.0)
+                Ok(self_.get().0 != other.0)
             }
             pyo3::basic::CompareOp::Gt => {
                 create_richcmp_notimplemented!('>', self_)
@@ -854,7 +852,7 @@ impl PyAttrsList {
             .map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected QualName or str for key, got {}",
-                    unsafe { crate::tools::get_type_name(py, key.as_ptr()) }
+                    crate::tools::get_type_name(key.bind(py))
                 ))
             })?;
 
@@ -865,7 +863,7 @@ impl PyAttrsList {
                 return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
                     format!(
                         "expected str for value, got {}",
-                        crate::tools::get_type_name(py, value.as_ptr())
+                        crate::tools::get_type_name(value.bind(py))
                     ),
                 ));
             }
@@ -897,7 +895,7 @@ impl PyAttrsList {
             .map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected QualName or str for key, got {}",
-                    unsafe { crate::tools::get_type_name(py, key.as_ptr()) }
+                    crate::tools::get_type_name(key.bind(py))
                 ))
             })?;
 
@@ -908,7 +906,7 @@ impl PyAttrsList {
                 return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
                     format!(
                         "expected str for value, got {}",
-                        crate::tools::get_type_name(py, value.as_ptr())
+                        crate::tools::get_type_name(value.bind(py))
                     ),
                 ));
             }
@@ -942,7 +940,7 @@ impl PyAttrsList {
             .map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected QualName or str for key, got {}",
-                    unsafe { crate::tools::get_type_name(py, key.as_ptr()) }
+                    crate::tools::get_type_name(key.bind(py))
                 ))
             })?;
 
@@ -953,7 +951,7 @@ impl PyAttrsList {
                 return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
                     format!(
                         "expected str for value, got {}",
-                        crate::tools::get_type_name(py, value.as_ptr())
+                        crate::tools::get_type_name(value.bind(py))
                     ),
                 ));
             }
@@ -990,7 +988,7 @@ impl PyAttrsList {
                 return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
                     format!(
                         "expected str for value, got {}",
-                        crate::tools::get_type_name(self_.py(), value.as_ptr())
+                        crate::tools::get_type_name(value.bind(self_.py()))
                     ),
                 ));
             }
@@ -1172,7 +1170,7 @@ impl PyElement {
             .map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected TreeDom for treedom, got {}",
-                    unsafe { crate::tools::get_type_name(treedom.py(), treedom.as_ptr()) }
+                    crate::tools::get_type_name(treedom)
                 ))
             })?;
 
@@ -1181,7 +1179,7 @@ impl PyElement {
             .map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected QualName or str for name, got {}",
-                    unsafe { crate::tools::get_type_name(treedom.py(), name.as_ptr()) }
+                    crate::tools::get_type_name(name.bind(treedom.py()))
                 ))
             })?;
 
@@ -1193,9 +1191,10 @@ impl PyElement {
                 Ok(x) => x,
                 Err(_) => {
                     return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                        format!("expected QualName or str for attrs #1, got {}", unsafe {
-                            crate::tools::get_type_name(treedom.py(), key.as_ptr())
-                        }),
+                        format!(
+                            "expected QualName or str for attrs #1, got {}",
+                            crate::tools::get_type_name(key.bind(treedom.py()))
+                        ),
                     ))
                 }
             };
@@ -1209,7 +1208,7 @@ impl PyElement {
                     return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
                         format!(
                             "expected str for attrs #2, got {}",
-                            crate::tools::get_type_name(treedom.py(), val.as_ptr())
+                            crate::tools::get_type_name(val.bind(treedom.py()))
                         ),
                     ));
                 }
@@ -1251,7 +1250,7 @@ impl PyElement {
             .map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected QualName or str for name, got {}",
-                    unsafe { crate::tools::get_type_name(name.py(), name.as_ptr()) }
+                    crate::tools::get_type_name(name)
                 ))
             })?;
 
@@ -1280,9 +1279,10 @@ impl PyElement {
                 Ok(x) => x,
                 Err(_) => {
                     return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                        format!("expected QualName or str for attrs #1, got {}", unsafe {
-                            crate::tools::get_type_name(py, key.as_ptr())
-                        }),
+                        format!(
+                            "expected QualName or str for attrs #1, got {}",
+                            crate::tools::get_type_name(key.bind(py))
+                        ),
                     ))
                 }
             };
@@ -1294,7 +1294,7 @@ impl PyElement {
                     return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
                         format!(
                             "expected str for attrs #2, got {}",
-                            crate::tools::get_type_name(py, val.as_ptr())
+                            crate::tools::get_type_name(val.bind(py))
                         ),
                     ));
                 }
@@ -1401,7 +1401,7 @@ impl PyElement {
     }
 
     fn __richcmp__(
-        self_: pyo3::PyRef<'_, Self>,
+        self_: pyo3::Bound<Self>,
         other: pyo3::Py<pyo3::PyAny>,
         cmp: pyo3::basic::CompareOp,
     ) -> pyo3::PyResult<bool> {
@@ -1418,7 +1418,7 @@ impl PyElement {
                     Err(_) => return Ok(false),
                 };
 
-                Ok(self_.0 == other.0)
+                Ok(self_.get().0 == other.0)
             }
             pyo3::basic::CompareOp::Ne => {
                 let other = match other.extract::<pyo3::PyRef<'_, Self>>(self_.py()) {
@@ -1426,7 +1426,7 @@ impl PyElement {
                     Err(_) => return Ok(false),
                 };
 
-                Ok(self_.0 != other.0)
+                Ok(self_.get().0 != other.0)
             }
             pyo3::basic::CompareOp::Gt => {
                 create_richcmp_notimplemented!('>', self_)
@@ -1466,7 +1466,7 @@ pub struct PyProcessingInstruction(pub(super) NodeGuard);
 impl PyProcessingInstruction {
     #[new]
     fn new(
-        treedom: &pyo3::Bound<'_, pyo3::PyAny>,
+        treedom: &pyo3::Bound<pyo3::PyAny>,
         data: String,
         target: String,
     ) -> pyo3::PyResult<Self> {
@@ -1475,7 +1475,7 @@ impl PyProcessingInstruction {
             .map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected TreeDom for treedom, got {}",
-                    unsafe { crate::tools::get_type_name(treedom.py(), treedom.as_ptr()) }
+                    crate::tools::get_type_name(treedom)
                 ))
             })?;
 
@@ -1557,7 +1557,7 @@ impl PyProcessingInstruction {
     }
 
     fn __richcmp__(
-        self_: pyo3::PyRef<'_, Self>,
+        self_: pyo3::Bound<Self>,
         other: pyo3::Py<pyo3::PyAny>,
         cmp: pyo3::basic::CompareOp,
     ) -> pyo3::PyResult<bool> {
@@ -1574,7 +1574,7 @@ impl PyProcessingInstruction {
                     Err(_) => return Ok(false),
                 };
 
-                Ok(self_.0 == other.0)
+                Ok(self_.get().0 == other.0)
             }
             pyo3::basic::CompareOp::Ne => {
                 let other = match other.extract::<pyo3::PyRef<'_, Self>>(self_.py()) {
@@ -1582,7 +1582,7 @@ impl PyProcessingInstruction {
                     Err(_) => return Ok(false),
                 };
 
-                Ok(self_.0 != other.0)
+                Ok(self_.get().0 != other.0)
             }
             pyo3::basic::CompareOp::Gt => {
                 create_richcmp_notimplemented!('>', self_)

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -106,49 +106,17 @@ impl NodeGuard {
     }
 
     pub fn from_pyobject(object: &pyo3::Bound<'_, pyo3::PyAny>) -> Result<Self, ()> {
-        use pyo3::type_object::PyTypeInfo;
-
-        if PyDocument::is_exact_type_of(object) {
-            let x = unsafe {
-                object
-                    .extract::<pyo3::PyRef<'_, PyDocument>>()
-                    .unwrap_unchecked()
-            };
+        if let Ok(x) = object.extract::<pyo3::PyRef<'_, PyDocument>>() {
             Ok(x.0.clone())
-        } else if PyDoctype::is_exact_type_of(object) {
-            let x = unsafe {
-                object
-                    .extract::<pyo3::PyRef<'_, PyDoctype>>()
-                    .unwrap_unchecked()
-            };
+        } else if let Ok(x) = object.extract::<pyo3::PyRef<'_, PyDoctype>>() {
             Ok(x.0.clone())
-        } else if PyComment::is_exact_type_of(object) {
-            let x = unsafe {
-                object
-                    .extract::<pyo3::PyRef<'_, PyComment>>()
-                    .unwrap_unchecked()
-            };
+        } else if let Ok(x) = object.extract::<pyo3::PyRef<'_, PyComment>>() {
             Ok(x.0.clone())
-        } else if PyText::is_exact_type_of(object) {
-            let x = unsafe {
-                object
-                    .extract::<pyo3::PyRef<'_, PyText>>()
-                    .unwrap_unchecked()
-            };
+        } else if let Ok(x) = object.extract::<pyo3::PyRef<'_, PyText>>() {
             Ok(x.0.clone())
-        } else if PyElement::is_exact_type_of(object) {
-            let x = unsafe {
-                object
-                    .extract::<pyo3::PyRef<'_, PyElement>>()
-                    .unwrap_unchecked()
-            };
+        } else if let Ok(x) = object.extract::<pyo3::PyRef<'_, PyElement>>() {
             Ok(x.0.clone())
-        } else if PyProcessingInstruction::is_exact_type_of(object) {
-            let x = unsafe {
-                object
-                    .extract::<pyo3::PyRef<'_, PyProcessingInstruction>>()
-                    .unwrap_unchecked()
-            };
+        } else if let Ok(x) = object.extract::<pyo3::PyRef<'_, PyProcessingInstruction>>() {
             Ok(x.0.clone())
         } else {
             Err(())
@@ -856,17 +824,13 @@ impl PyAttrsList {
                 ))
             })?;
 
-        let val = unsafe {
-            if pyo3::ffi::PyUnicode_CheckExact(value.as_ptr()) == 1 {
-                value.bind(py).extract::<String>().unwrap_unchecked()
-            } else {
-                return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                    format!(
-                        "expected str for value, got {}",
-                        crate::tools::get_type_name(value.bind(py))
-                    ),
-                ));
-            }
+        let Ok(val) = value.bind(py).extract::<String>() else {
+            return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                format!(
+                    "expected str for value, got {}",
+                    crate::tools::get_type_name(value.bind(py))
+                ),
+            ));
         };
 
         let mut tree = self.0.tree.lock();
@@ -899,17 +863,13 @@ impl PyAttrsList {
                 ))
             })?;
 
-        let val = unsafe {
-            if pyo3::ffi::PyUnicode_CheckExact(value.as_ptr()) == 1 {
-                value.bind(py).extract::<String>().unwrap_unchecked()
-            } else {
-                return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                    format!(
-                        "expected str for value, got {}",
-                        crate::tools::get_type_name(value.bind(py))
-                    ),
-                ));
-            }
+        let Ok(val) = value.bind(py).extract::<String>() else {
+            return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                format!(
+                    "expected str for value, got {}",
+                    crate::tools::get_type_name(value.bind(py))
+                ),
+            ));
         };
 
         let mut tree = self.0.tree.lock();
@@ -944,17 +904,13 @@ impl PyAttrsList {
                 ))
             })?;
 
-        let val = unsafe {
-            if pyo3::ffi::PyUnicode_CheckExact(value.as_ptr()) == 1 {
-                value.bind(py).extract::<String>().unwrap_unchecked()
-            } else {
-                return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                    format!(
-                        "expected str for value, got {}",
-                        crate::tools::get_type_name(value.bind(py))
-                    ),
-                ));
-            }
+        let Ok(val) = value.bind(py).extract::<String>() else {
+            return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                format!(
+                    "expected str for value, got {}",
+                    crate::tools::get_type_name(value.bind(py))
+                ),
+            ));
         };
 
         let mut tree = self.0.tree.lock();
@@ -978,20 +934,13 @@ impl PyAttrsList {
         index: usize,
         value: pyo3::Py<pyo3::PyAny>,
     ) -> pyo3::PyResult<()> {
-        let value = unsafe {
-            if pyo3::ffi::PyUnicode_CheckExact(value.as_ptr()) == 1 {
-                value
-                    .bind(self_.py())
-                    .extract::<String>()
-                    .unwrap_unchecked()
-            } else {
-                return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                    format!(
-                        "expected str for value, got {}",
-                        crate::tools::get_type_name(value.bind(self_.py()))
-                    ),
-                ));
-            }
+        let Ok(value) = value.bind(self_.py()).extract::<String>() else {
+            return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                format!(
+                    "expected str for value, got {}",
+                    crate::tools::get_type_name(value.bind(self_.py()))
+                ),
+            ));
         };
 
         let mut tree = self_.0.tree.lock();
@@ -1199,19 +1148,13 @@ impl PyElement {
                 }
             };
 
-            let val = unsafe {
-                if pyo3::ffi::PyUnicode_Check(val.as_ptr()) == 1 {
-                    val.bind(treedom.py())
-                        .extract::<String>()
-                        .unwrap_unchecked()
-                } else {
-                    return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                        format!(
-                            "expected str for attrs #2, got {}",
-                            crate::tools::get_type_name(val.bind(treedom.py()))
-                        ),
-                    ));
-                }
+            let Ok(val) = val.bind(treedom.py()).extract::<String>() else {
+                return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                    format!(
+                        "expected str for attrs #2, got {}",
+                        crate::tools::get_type_name(val.bind(treedom.py()))
+                    ),
+                ));
             };
 
             attributes.push((key, treedom::atomic::AtomicTendril::from(val)));
@@ -1287,17 +1230,13 @@ impl PyElement {
                 }
             };
 
-            let val = unsafe {
-                if pyo3::ffi::PyUnicode_Check(val.as_ptr()) == 1 {
-                    val.bind(py).extract::<String>().unwrap_unchecked()
-                } else {
-                    return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                        format!(
-                            "expected str for attrs #2, got {}",
-                            crate::tools::get_type_name(val.bind(py))
-                        ),
-                    ));
-                }
+            let Ok(val) = val.bind(py).extract::<String>() else {
+                return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                    format!(
+                        "expected str for attrs #2, got {}",
+                        crate::tools::get_type_name(val.bind(py))
+                    ),
+                ));
             };
 
             attributes.push((

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -295,20 +295,17 @@ impl PyParser {
     ///
     /// Raises `RuntimeError` if `.finish()` method is called.
     fn process(&self, content: &pyo3::Bound<'_, pyo3::PyAny>) -> pyo3::PyResult<()> {
-        let content = unsafe {
-            if pyo3::ffi::PyBytes_Check(content.as_ptr()) == 1 {
-                content.extract::<Vec<u8>>().unwrap()
-            } else if pyo3::ffi::PyUnicode_Check(content.as_ptr()) == 1 {
-                let s = content.extract::<String>().unwrap();
-                s.into_bytes()
-            } else {
-                return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                    format!(
-                        "expected bytes or str for content, got {}",
-                        crate::tools::get_type_name(content)
-                    ),
-                ));
-            }
+        let content = if let Ok(b) = content.extract::<Vec<u8>>() {
+            b
+        } else if let Ok(s) = content.extract::<String>() {
+            s.into_bytes()
+        } else {
+            return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                format!(
+                    "expected bytes or str for content, got {}",
+                    crate::tools::get_type_name(content)
+                ),
+            ));
         };
 
         let mut state = self.state.lock();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -278,7 +278,7 @@ impl PyParser {
                 return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
                     format!(
                         "expected HtmlOptions or XmlOptions for options, got {}",
-                        unsafe { crate::tools::get_type_name(options.py(), options.as_ptr()) }
+                        crate::tools::get_type_name(options)
                     ),
                 ));
             }
@@ -305,7 +305,7 @@ impl PyParser {
                 return Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
                     format!(
                         "expected bytes or str for content, got {}",
-                        crate::tools::get_type_name(content.py(), content.as_ptr())
+                        crate::tools::get_type_name(content)
                     ),
                 ));
             }
@@ -424,7 +424,7 @@ pub fn serialize(
     let node = super::nodes::NodeGuard::from_pyobject(node).map_err(|_| {
         pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
             "expected an node (such as Element, Text, Comment, ...) for node, got {}",
-            unsafe { crate::tools::get_type_name(node.py(), node.as_ptr()) }
+            crate::tools::get_type_name(node)
         ))
     })?;
 

--- a/src/qualname.rs
+++ b/src/qualname.rs
@@ -123,7 +123,7 @@ impl PyQualName {
     }
 
     fn __richcmp__(
-        self_: pyo3::PyRef<'_, Self>,
+        self_: pyo3::Bound<Self>,
         other: pyo3::Py<pyo3::PyAny>,
         cmp: pyo3::basic::CompareOp,
     ) -> pyo3::PyResult<bool> {
@@ -134,36 +134,35 @@ impl PyQualName {
         }
 
         macro_rules! create_error {
-            ($token:expr, $selfobj:expr, $otherobj:expr) => {
-                unsafe {
-                    Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                        format!(
-                            "'{}' not supported between '{}' and '{}'",
-                            $token,
-                            crate::tools::get_type_name($selfobj.py(), $selfobj.as_ptr()),
-                            crate::tools::get_type_name($selfobj.py(), $otherobj.as_ptr()),
-                        ),
-                    ))
-                }
-            };
+            ($token:expr, $selfobj:expr, $otherobj:expr) => {{
+                let py = $selfobj.py();
+                Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                    format!(
+                        "'{}' not supported between '{}' and '{}'",
+                        $token,
+                        crate::tools::get_type_name(&$selfobj),
+                        crate::tools::get_type_name($otherobj.bind(py)),
+                    ),
+                ))
+            }};
         }
 
         match cmp {
             pyo3::basic::CompareOp::Eq => {
                 match crate::tools::qualname_from_pyobject(self_.py(), &other) {
                     crate::tools::QualNameFromPyObjectResult::QualName(x) => {
-                        Ok(x.name == self_.name)
+                        Ok(x.name == self_.get().name)
                     }
-                    crate::tools::QualNameFromPyObjectResult::Str(x) => Ok(self_.name.local == x),
+                    crate::tools::QualNameFromPyObjectResult::Str(x) => Ok(self_.get().name.local == x),
                     crate::tools::QualNameFromPyObjectResult::Err(_) => Ok(false),
                 }
             }
             pyo3::basic::CompareOp::Ne => {
                 match crate::tools::qualname_from_pyobject(self_.py(), &other) {
                     crate::tools::QualNameFromPyObjectResult::QualName(x) => {
-                        Ok(x.name != self_.name)
+                        Ok(x.name != self_.get().name)
                     }
-                    crate::tools::QualNameFromPyObjectResult::Str(x) => Ok(self_.name.local != x),
+                    crate::tools::QualNameFromPyObjectResult::Str(x) => Ok(self_.get().name.local != x),
                     crate::tools::QualNameFromPyObjectResult::Err(_) => Ok(true),
                 }
             }
@@ -173,7 +172,7 @@ impl PyQualName {
                     Err(_) => return create_error!('>', self_, other),
                 };
 
-                Ok(self_.name > other.name)
+                Ok(self_.get().name > other.name)
             }
             pyo3::basic::CompareOp::Lt => {
                 let other = match other.extract::<pyo3::PyRef<'_, Self>>(self_.py()) {
@@ -181,7 +180,7 @@ impl PyQualName {
                     Err(_) => return create_error!('<', self_, other),
                 };
 
-                Ok(self_.name < other.name)
+                Ok(self_.get().name < other.name)
             }
             pyo3::basic::CompareOp::Le => {
                 let other = match other.extract::<pyo3::PyRef<'_, Self>>(self_.py()) {
@@ -189,7 +188,7 @@ impl PyQualName {
                     Err(_) => return create_error!("<=", self_, other),
                 };
 
-                Ok(self_.name <= other.name)
+                Ok(self_.get().name <= other.name)
             }
             pyo3::basic::CompareOp::Ge => {
                 let other = match other.extract::<pyo3::PyRef<'_, Self>>(self_.py()) {
@@ -197,7 +196,7 @@ impl PyQualName {
                     Err(_) => return create_error!(">=", self_, other),
                 };
 
-                Ok(self_.name >= other.name)
+                Ok(self_.get().name >= other.name)
             }
         }
     }

--- a/src/select.rs
+++ b/src/select.rs
@@ -70,7 +70,7 @@ impl PySelect {
         let node = crate::nodes::NodeGuard::from_pyobject(node).map_err(|_| {
             pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                 "expected a node (such as Element, Text, Comment, ...) for node, got {}",
-                unsafe { crate::tools::get_type_name(node.py(), node.as_ptr()) }
+                crate::tools::get_type_name(node)
             ))
         })?;
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -33,17 +33,16 @@ pub fn qualname_from_pyobject<'a>(
     object: &pyo3::Py<pyo3::PyAny>,
 ) -> QualNameFromPyObjectResult<'a> {
     use pyo3::types::PyAnyMethods;
-    unsafe {
-        if pyo3::ffi::PyUnicode_Check(object.as_ptr()) == 1 {
-            QualNameFromPyObjectResult::Str(object.bind(py).extract::<String>().unwrap_unchecked())
-        } else {
-            match object
-                .bind(py)
-                .extract::<pyo3::PyRef<'_, crate::qualname::PyQualName>>()
-            {
-                Ok(x) => QualNameFromPyObjectResult::QualName(x),
-                Err(e) => QualNameFromPyObjectResult::Err(e.into()),
-            }
+
+    if let Ok(x) = object.bind(py).extract::<String>() {
+        QualNameFromPyObjectResult::Str(x)
+    } else {
+        match object
+            .bind(py)
+            .extract::<pyo3::PyRef<'_, crate::qualname::PyQualName>>()
+        {
+            Ok(x) => QualNameFromPyObjectResult::QualName(x),
+            Err(e) => QualNameFromPyObjectResult::Err(e.into()),
         }
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,18 +1,11 @@
-use pyo3::types::{PyStringMethods, PyTypeMethods};
+use pyo3::types::{PyAnyMethods, PyStringMethods, PyTypeMethods};
 
 /// Returns the type name of a [`pyo3::ffi::PyObject`].
 ///
 /// Returns `"<unknown>"` on failure.
-pub unsafe fn get_type_name(py: pyo3::Python<'_>, obj: *mut pyo3::ffi::PyObject) -> String {
-    let type_ = unsafe { (*obj).ob_type };
-
-    if type_.is_null() {
-        String::from("<unknown>")
-    } else {
-        let obj = unsafe { pyo3::types::PyType::from_borrowed_type_ptr(py, type_) };
-
-        obj.name().unwrap().to_str().unwrap().into()
-    }
+pub fn get_type_name(obj: &pyo3::Bound<pyo3::PyAny>) -> String {
+    let type_ = obj.get_type();
+    type_.name().unwrap().to_str().unwrap().into()
 }
 
 pub enum QualNameFromPyObjectResult<'p> {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -86,7 +86,7 @@ impl PyTreeDom {
                 .map_err(|_| {
                     pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                         "expected dict[str, str] for namespaces, got {}",
-                        unsafe { crate::tools::get_type_name(cls.py(), namespaces.as_ptr()) }
+                        crate::tools::get_type_name(namespaces.bind(cls.py()))
                     ))
                 })?;
 
@@ -94,14 +94,14 @@ impl PyTreeDom {
                 let key = key.cast::<pyo3::types::PyString>().map_err(|_| {
                     pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                         "expected dict[str, str] for namespaces, but found a key with type {} (keys must be strings)",
-                        unsafe { crate::tools::get_type_name(cls.py(), key.as_ptr()) }
+                        crate::tools::get_type_name(&key)
                     ))
                 }).map(|x| pyo3::types::PyStringMethods::to_string_lossy(x).into_owned())?;
 
                 let val = val.cast::<pyo3::types::PyString>().map_err(|_| {
                     pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                         "expected dict[str, str] for namespaces, but found a value with type {} (values must be strings)",
-                        unsafe { crate::tools::get_type_name(cls.py(), val.as_ptr()) }
+                        crate::tools::get_type_name(&val)
                     ))
                 }).map(|x| pyo3::types::PyStringMethods::to_string_lossy(x).into_owned())?;
 
@@ -158,7 +158,7 @@ impl PyTreeDom {
             super::nodes::NodeGuard::from_pyobject(parent.bind(self_.py())).map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected an node (such as Element, Text, Comment, ...) for parent, got {}",
-                    unsafe { crate::tools::get_type_name(self_.py(), parent.as_ptr()) }
+                    crate::tools::get_type_name(parent.bind(self_.py()))
                 ))
             })?;
 
@@ -166,7 +166,7 @@ impl PyTreeDom {
             super::nodes::NodeGuard::from_pyobject(child.bind(self_.py())).map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected an node (such as Element, Text, Comment, ...) for child, got {}",
-                    unsafe { crate::tools::get_type_name(self_.py(), child.as_ptr()) }
+                    crate::tools::get_type_name(child.bind(self_.py()))
                 ))
             })?;
 
@@ -207,7 +207,7 @@ impl PyTreeDom {
             super::nodes::NodeGuard::from_pyobject(parent.bind(self_.py())).map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected an node (such as Element, Text, Comment, ...) for parent, got {}",
-                    unsafe { crate::tools::get_type_name(self_.py(), parent.as_ptr()) }
+                    crate::tools::get_type_name(parent.bind(self_.py()))
                 ))
             })?;
 
@@ -215,7 +215,7 @@ impl PyTreeDom {
             super::nodes::NodeGuard::from_pyobject(child.bind(self_.py())).map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected an node (such as Element, Text, Comment, ...) for child, got {}",
-                    unsafe { crate::tools::get_type_name(self_.py(), child.as_ptr()) }
+                    crate::tools::get_type_name(child.bind(self_.py()))
                 ))
             })?;
 
@@ -256,7 +256,7 @@ impl PyTreeDom {
             super::nodes::NodeGuard::from_pyobject(parent.bind(self_.py())).map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected an node (such as Element, Text, Comment, ...) for parent, got {}",
-                    unsafe { crate::tools::get_type_name(self_.py(), parent.as_ptr()) }
+                    crate::tools::get_type_name(parent.bind(self_.py()))
                 ))
             })?;
 
@@ -264,7 +264,7 @@ impl PyTreeDom {
             super::nodes::NodeGuard::from_pyobject(child.bind(self_.py())).map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected an node (such as Element, Text, Comment, ...) for child, got {}",
-                    unsafe { crate::tools::get_type_name(self_.py(), child.as_ptr()) }
+                    crate::tools::get_type_name(child.bind(self_.py()))
                 ))
             })?;
 
@@ -305,7 +305,7 @@ impl PyTreeDom {
             super::nodes::NodeGuard::from_pyobject(parent.bind(self_.py())).map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected an node (such as Element, Text, Comment, ...) for parent, got {}",
-                    unsafe { crate::tools::get_type_name(self_.py(), parent.as_ptr()) }
+                    crate::tools::get_type_name(parent.bind(self_.py()))
                 ))
             })?;
 
@@ -313,7 +313,7 @@ impl PyTreeDom {
             super::nodes::NodeGuard::from_pyobject(child.bind(self_.py())).map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected an node (such as Element, Text, Comment, ...) for child, got {}",
-                    unsafe { crate::tools::get_type_name(self_.py(), child.as_ptr()) }
+                    crate::tools::get_type_name(child.bind(self_.py()))
                 ))
             })?;
 
@@ -349,7 +349,7 @@ impl PyTreeDom {
         let node = super::nodes::NodeGuard::from_pyobject(node.bind(self_.py())).map_err(|_| {
             pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                 "expected an node (such as Element, Text, Comment, ...) for node, got {}",
-                unsafe { crate::tools::get_type_name(self_.py(), node.as_ptr()) }
+                crate::tools::get_type_name(node.bind(self_.py()))
             ))
         })?;
 
@@ -380,7 +380,7 @@ impl PyTreeDom {
             super::nodes::NodeGuard::from_pyobject(parent.bind(self_.py())).map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected an node (such as Element, Text, Comment, ...) for parent, got {}",
-                    unsafe { crate::tools::get_type_name(self_.py(), parent.as_ptr()) }
+                    crate::tools::get_type_name(parent.bind(self_.py()))
                 ))
             })?;
 
@@ -388,7 +388,7 @@ impl PyTreeDom {
             super::nodes::NodeGuard::from_pyobject(child.bind(self_.py())).map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected an node (such as Element, Text, Comment, ...) for child, got {}",
-                    unsafe { crate::tools::get_type_name(self_.py(), child.as_ptr()) }
+                    crate::tools::get_type_name(child.bind(self_.py()))
                 ))
             })?;
 
@@ -421,7 +421,7 @@ impl PyTreeDom {
             super::nodes::NodeGuard::from_pyobject(parent.bind(self_.py())).map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected an node (such as Element, Text, Comment, ...) for parent, got {}",
-                    unsafe { crate::tools::get_type_name(self_.py(), parent.as_ptr()) }
+                    crate::tools::get_type_name(parent.bind(self_.py()))
                 ))
             })?;
 
@@ -429,7 +429,7 @@ impl PyTreeDom {
             super::nodes::NodeGuard::from_pyobject(child.bind(self_.py())).map_err(|_| {
                 pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
                     "expected an node (such as Element, Text, Comment, ...) for child, got {}",
-                    unsafe { crate::tools::get_type_name(self_.py(), child.as_ptr()) }
+                    crate::tools::get_type_name(child.bind(self_.py()))
                 ))
             })?;
 
@@ -454,7 +454,7 @@ impl PyTreeDom {
     }
 
     fn __richcmp__(
-        self_: pyo3::PyRef<'_, Self>,
+        self_: pyo3::Bound<Self>,
         other: pyo3::Py<pyo3::PyAny>,
         cmp: pyo3::basic::CompareOp,
     ) -> pyo3::PyResult<bool> {
@@ -471,10 +471,10 @@ impl PyTreeDom {
                     Err(_) => return Ok(false),
                 };
 
-                if Arc::ptr_eq(&self_.dom, &other.dom) {
+                if Arc::ptr_eq(&self_.get().dom, &other.dom) {
                     Ok(true)
                 } else {
-                    let t1 = self_.dom.lock();
+                    let t1 = self_.get().dom.lock();
                     let t2 = other.dom.lock();
 
                     Ok(*t1 == *t2)
@@ -486,10 +486,10 @@ impl PyTreeDom {
                     Err(_) => return Ok(false),
                 };
 
-                if Arc::ptr_eq(&self_.dom, &other.dom) {
+                if Arc::ptr_eq(&self_.get().dom, &other.dom) {
                     Ok(false)
                 } else {
-                    let t1 = self_.dom.lock();
+                    let t1 = self_.get().dom.lock();
                     let t2 = other.dom.lock();
 
                     Ok(*t1 != *t2)


### PR DESCRIPTION
The documentation claims this library “avoids the use of `unsafe` code blocks”:

https://github.com/awolverp/markupever/blob/1358434d54c06ee653bf07cd9a2ec7423bdf96a2/docs/docs/index.md#L220

That’s not currently true, but it should be. At least 63 of the 75 `unsafe` blocks have no real reason to be there—remove them.