### PR TITLE
Upgrade dependencies, including html5ever 0.38.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ panic = "abort"
 strip = "symbols"
 
 [dependencies]
-pyo3 = { version = "0.27", default-features = false, features = [
+pyo3 = { version = "0.28", default-features = false, features = [
     "macros",
     "extension-module",
     "generate-import-lib",
@@ -42,13 +42,13 @@ pyo3 = { version = "0.27", default-features = false, features = [
 parking_lot = { version = "0.12" }
 treedom = { path = "treedom" }
 matching = { path = "matching" }
-hashbrown = { version = "0.15", default-features = false, features = [
+hashbrown = { version = "0.16", default-features = false, features = [
     "default-hasher",
     "inline-more",
 ] }
 
 [build-dependencies]
-pyo3-build-config = { version = "0.27", features = ["resolve-config"] }
+pyo3-build-config = { version = "0.28", features = ["resolve-config"] }
 
 [lints.clippy]
 dbg_macro = "warn"

--- a/matching/Cargo.toml
+++ b/matching/Cargo.toml
@@ -10,12 +10,12 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
-cssparser = { version = "0.34.0" }
+cssparser = { version = "0.36.0" }
 precomputed-hash = { version = "0.1.1" }
-selectors = { version = "0.26.0" }
-tendril = { version = "0.4" }
+selectors = { version = "0.35.0" }
+tendril = { version = "0.5" }
 treedom = { path = "../treedom"}
-hashbrown = { version = "0.15", default-features = false, features = [
+hashbrown = { version = "0.16", default-features = false, features = [
     "default-hasher",
     "inline-more",
 ] }

--- a/matching/src/selectable.rs
+++ b/matching/src/selectable.rs
@@ -1,4 +1,4 @@
-use treedom::markup5ever::{namespace_url, ns};
+use treedom::markup5ever::ns;
 
 /// A selectable [`treedom::ego_tree::NodeRef`]
 #[derive(Debug, Clone)]

--- a/treedom/Cargo.toml
+++ b/treedom/Cargo.toml
@@ -10,13 +10,13 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
-html5ever = { version = "0.29.1", optional = true }
-markup5ever = { version = "0.14.1" }
+html5ever = { version = "0.38.0", optional = true }
+markup5ever = { version = "0.38.0" }
 parking_lot = { version = "0.12" }
-xml5ever = { version = "0.20.0", optional = true }
-tendril = { version = "^0.4" }
-hashbrown = { version = "0.15", default-features = false}
-ego-tree = { version = "0.10.0" }
+xml5ever = { version = "0.38.0", optional = true }
+tendril = { version = "^0.5" }
+hashbrown = { version = "0.16", default-features = false}
+ego-tree = { version = "0.11.0" }
 
 [features]
 default = ["html5ever", "xml5ever"]

--- a/treedom/src/parser.rs
+++ b/treedom/src/parser.rs
@@ -86,6 +86,7 @@ impl ParserSink {
                     markup5ever::local_name!("body"),
                 ),
                 Vec::new(),
+                true,
             )
         }
     }


### PR DESCRIPTION
This adds some deprecation warnings for our use of `pyo3::Py::<T>::from_owned_ptr`, but I removed that in #6, so I’ll just ignore them here to avoid conflicts.

Improves our score on the [justhtml correctness test](https://emilstenstrom.github.io/justhtml/correctness.html) from 1652/1743 to 1673/1743.